### PR TITLE
Generate Unescaped Unicode in JSON

### DIFF
--- a/Classes/Mvc/View/JsonLdView.php
+++ b/Classes/Mvc/View/JsonLdView.php
@@ -48,7 +48,7 @@ class JsonLdView extends JsonView
     {
         $this->controllerContext->getResponse()->setHeader('Content-Type', 'application/ld+json');
         $propertiesToRender = $this->renderArray();
-        return json_encode($propertiesToRender, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        return json_encode($propertiesToRender, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }/** @noinspection PhpMissingParentCallCommonInspection */
 
     /**


### PR DESCRIPTION
Unicode characters we converted by json_encode into numeric codes in page source. Adding JSON_UNESCAPED_UNICODE as an encode option means the text is now human readable in page source.