### PR TITLE
 If entity is set to null, do not render Json-Container.

### DIFF
--- a/Classes/Controller/EntityController.php
+++ b/Classes/Controller/EntityController.php
@@ -85,8 +85,10 @@ class EntityController extends ActionController
                 $settings = isset($processorConfiguration['settings']) ? $processorConfiguration['settings'] : [];
                 $processor->process($entity, $settings);
             }
-
-            $this->view->assign('entity', $entity);
+            
+            if ($entity) {
+                $this->view->assign('entity', $entity);
+            }
         }
 
     }

--- a/Classes/Mvc/View/JsonLdView.php
+++ b/Classes/Mvc/View/JsonLdView.php
@@ -48,7 +48,11 @@ class JsonLdView extends JsonView
     {
         $this->controllerContext->getResponse()->setHeader('Content-Type', 'application/ld+json');
         $propertiesToRender = $this->renderArray();
-        return json_encode($propertiesToRender, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if (is_array($propertiesToRender)) {
+            return json_encode($propertiesToRender, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        } else {
+            return;
+        }
     }/** @noinspection PhpMissingParentCallCommonInspection */
 
     /**


### PR DESCRIPTION
I use the plugin for creating FAQ-snippets varying pages. I had the problem that the Json-container was shown, even if there was no FAQ. I think it should be possible to suppress the output of the Json-Container if there is no Rich-Element.